### PR TITLE
Remove redundant '-mode' suffix

### DIFF
--- a/ob-blockdiag.el
+++ b/ob-blockdiag.el
@@ -29,7 +29,7 @@
     (:size    . nil))
   "Default arguments for drawing a blockdiag image.")
 
-(add-to-list 'org-src-lang-modes '("blockdiag" . blockdiag-mode))
+(add-to-list 'org-src-lang-modes '("blockdiag" . blockdiag))
 
 (defun org-babel-execute:blockdiag (body params)
   (let ((file (cdr (assoc :file params)))


### PR DESCRIPTION
There is no need to add '-mode' suffix, since it will be appended automatically.